### PR TITLE
add support for retrying failed requests

### DIFF
--- a/hubitatmaker/hub.py
+++ b/hubitatmaker/hub.py
@@ -7,6 +7,7 @@ from types import MappingProxyType
 from typing import Any, Callable, Dict, Iterator, List, Mapping, Optional, Union
 from urllib.parse import ParseResult, quote, urlparse
 
+import asyncio
 import aiohttp
 import getmac
 
@@ -17,6 +18,8 @@ from .types import Device, Event, Mode
 
 Listener = Callable[[Event], None]
 
+MAX_REQUEST_ATTEMPT_COUNT = 3
+REQUEST_RETRY_DELAY_INTERVAL = 0.5
 
 _LOGGER = getLogger(__name__)
 
@@ -367,22 +370,47 @@ class Hub:
     async def _api_request(self, path: str, method="GET") -> Any:
         """Make a Maker API request."""
         params = {"access_token": self.token}
-        conn = aiohttp.TCPConnector(ssl=False)
-        try:
-            async with aiohttp.request(
-                method, f"{self.api_url}/{path}", params=params, connector=conn
-            ) as resp:
-                if resp.status >= 400:
-                    if resp.status == 401:
-                        raise InvalidToken()
-                    else:
+
+        attempt = 0
+        while attempt <= MAX_REQUEST_ATTEMPT_COUNT:
+            attempt += 1
+            conn = aiohttp.TCPConnector(ssl=False)
+            try:
+                async with aiohttp.request(
+                    method, f"{self.api_url}/{path}", params=params, connector=conn
+                ) as resp:
+                    if resp.status >= 400:
+                        # retry on server errors or request timeout w/ increasing delay
+                        if resp.status >= 500 or resp.status == 408:
+                            if attempt < MAX_REQUEST_ATTEMPT_COUNT:
+                                _LOGGER.debug(
+                                    "%s request to %s failed with code %d: %s. Retrying...",
+                                    method, path, resp.status, resp.reason
+                                )
+                                await asyncio.sleep(attempt * REQUEST_RETRY_DELAY_INTERVAL)
+                                continue
+
+                        if resp.status == 401:
+                            raise InvalidToken()
+                        else:
+                            raise RequestError(resp)
+                    json = await resp.json()
+                    if "error" in json and json["error"]:
                         raise RequestError(resp)
-                json = await resp.json()
-                if "error" in json and json["error"]:
-                    raise RequestError(resp)
-                return json
-        finally:
-            await conn.close()
+                    return json
+            except (aiohttp.ClientConnectionError, asyncio.TimeoutError) as e:
+                # catch connection exceptions to retry w/ increasing delay
+                if attempt < MAX_REQUEST_ATTEMPT_COUNT:
+                    _LOGGER.debug(
+                        "%s request to %s failed with %s. Retrying...",
+                        method, path, str(e)
+                    )
+                    await asyncio.sleep(attempt * REQUEST_RETRY_DELAY_INTERVAL)
+                    continue
+                else:
+                    raise e
+            finally:
+                await conn.close()
 
     async def _start_server(self) -> None:
         """Start an event listener server."""


### PR DESCRIPTION
For retryable errors like server errors and timeouts, retry the request up to 2 more times with increasing delay in between. Running this locally with no problems so far